### PR TITLE
Use system blas for arrays

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject techascent/tech.compute "1.14-SNAPSHOT"
+(defproject techascent/tech.compute "1.14"
   :description "Library designed to provide a generic compute abstraction to allow some level of shared implementation between a cpu, cuda, openCL, webworkers, etc."
   :url "http://github.com/tech-ascent/tech.compute"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [techascent/tech.javacpp-datatype "1.11"]
+                 [techascent/tech.javacpp-datatype "2.1"]
                  [techascent/tech.parallel "1.0"]
                  ;;Backup for if we can't load system blas.  We then do array-backed
                  ;;nio buffers and use the netlib blas (most likely a lot slower).

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [techascent/tech.javacpp-datatype "2.1"]
+                 [techascent/tech.javacpp-datatype "2.2"]
                  [techascent/tech.parallel "1.0"]
                  ;;Backup for if we can't load system blas.  We then do array-backed
                  ;;nio buffers and use the netlib blas (most likely a lot slower).

--- a/src/tech/compute/cpu/driver.clj
+++ b/src/tech/compute/cpu/driver.clj
@@ -180,10 +180,13 @@ Use with care; the synchonization primitives will just hang with this stream."
 
 
 (defn- make-typed-thing
-  [datatype n-elems]
-  (if (jna-blas/has-blas?)
-    (dtype-jna/make-typed-pointer datatype n-elems)
-    (unsigned/make-typed-buffer datatype n-elems)))
+  [datatype n-elems options]
+  (if (contains? options :container-fn)
+    ((:container-fn options) datatype n-elems)
+    (if (= datatype
+           (unsigned/datatype->jvm-datatype datatype))
+      (dtype/make-array-of-type datatype n-elems options)
+      (unsigned/make-typed-buffer datatype n-elems))))
 
 
 
@@ -203,7 +206,7 @@ Use with care; the synchonization primitives will just hang with this stream."
 
   (allocate-device-buffer [impl elem-count elem-type options]
     (check-stream-error-atom impl)
-    (make-typed-thing elem-type elem-count))
+    (make-typed-thing elem-type elem-count options))
 
   (acceptable-device-buffer? [device item]
     (and (or (dtype-jna/typed-pointer? item)
@@ -222,7 +225,7 @@ Use with care; the synchonization primitives will just hang with this stream."
 
   (allocate-host-buffer [impl elem-count elem-type options]
     (check-stream-error-atom impl)
-    (make-typed-thing elem-type elem-count)))
+    (make-typed-thing elem-type elem-count options)))
 
 
 (declare default-cpu-stream)

--- a/src/tech/compute/cpu/driver.clj
+++ b/src/tech/compute/cpu/driver.clj
@@ -179,13 +179,15 @@ Use with care; the synchonization primitives will just hang with this stream."
     retval))
 
 
+(def ^:dynamic *default-container-fn* dtype/make-array-of-type)
+
+
 (defn- make-typed-thing
   [datatype n-elems options]
   (if (contains? options :container-fn)
     ((:container-fn options) datatype n-elems)
-    (if (= datatype
-           (unsigned/datatype->jvm-datatype datatype))
-      (dtype/make-array-of-type datatype n-elems options)
+    (if (primitive/is-jvm-datatype? datatype)
+      (*default-container-fn* datatype n-elems options)
       (unsigned/make-typed-buffer datatype n-elems))))
 
 

--- a/src/tech/compute/cpu/jna_blas.clj
+++ b/src/tech/compute/cpu/jna_blas.clj
@@ -1,6 +1,7 @@
 (ns tech.compute.cpu.jna-blas
   (:require [tech.datatype.jna :as dtype-jna]
             [tech.datatype :as dtype]
+            [tech.datatype.java-primitive :as primitive]
             [tech.compute.tensor.error-checking :as error-checking])
   (:import [com.sun.jna Pointer Native Function NativeLibrary]))
 
@@ -122,12 +123,12 @@
                        (int N)
                        (int K)
                        (float alpha)
-                       (dtype-jna/->ptr-backing-store A)
+                       (primitive/->buffer-backing-store A)
                        (int lda)
-                       (dtype-jna/->ptr-backing-store B)
+                       (primitive/->buffer-backing-store B)
                        (int ldb)
                        (float beta)
-                       (dtype-jna/->ptr-backing-store C)
+                       (primitive/->buffer-backing-store C)
                        (int ldc)]))))
 
 
@@ -144,10 +145,10 @@
                        (int N)
                        (int K)
                        (double alpha)
-                       (dtype-jna/->ptr-backing-store A)
+                       (primitive/->buffer-backing-store A)
                        (int lda)
-                       (dtype-jna/->ptr-backing-store B)
+                       (primitive/->buffer-backing-store B)
                        (int ldb)
                        (double beta)
-                       (dtype-jna/->ptr-backing-store C)
+                       (primitive/->buffer-backing-store C)
                        (int ldc)]))))

--- a/src/tech/compute/cpu/jna_blas.clj
+++ b/src/tech/compute/cpu/jna_blas.clj
@@ -90,7 +90,7 @@
 (jna/def-jna-fn *system-blas-lib-name* cblas_sgemm
   "float32 gemm"
   nil
-  [order int]
+  [order enum-value]
   [trans-a? bool->blas-transpose]
   [trans-b? bool->blas-transpose]
   [M int]
@@ -109,7 +109,7 @@
 (jna/def-jna-fn *system-blas-lib-name* cblas_dgemm
   "float64 gemm"
   nil
-  [order int]
+  [order enum-value]
   [trans-a? bool->blas-transpose]
   [trans-b? bool->blas-transpose]
   [M int]

--- a/src/tech/compute/cpu/jna_blas.clj
+++ b/src/tech/compute/cpu/jna_blas.clj
@@ -1,55 +1,43 @@
 (ns tech.compute.cpu.jna-blas
-  (:require [tech.datatype.jna :as dtype-jna]
-            [tech.datatype :as dtype]
+  (:require [tech.datatype :as dtype]
             [tech.datatype.java-primitive :as primitive]
-            [tech.compute.tensor.error-checking :as error-checking])
-  (:import [com.sun.jna Pointer Native Function NativeLibrary]))
+            [tech.compute.tensor.error-checking :as error-checking]
+            [tech.jna :as jna]))
 
 
 (def ^:dynamic *system-blas-lib-name* "blas")
 
 
-(def ^:private try-load-blas
-  (memoize
-   (fn [libname]
-     (try
-       (NativeLibrary/getInstance libname)
-       (catch Throwable e
-         (println "Failed to load native blas:" (.getMessage e))
-         nil)))))
-
-
 (defn ^:private system-blas-lib
   []
-  (try-load-blas *system-blas-lib-name*))
+  (try
+    (jna/load-library *system-blas-lib-name*)
+    (catch Throwable e
+      (println "Failed to load native blas:" (.getMessage e))
+      nil)))
 
-
-(def get-blas-fn
-  (memoize
-   (fn [^String fn-name]
-     (when-let [system-blas (system-blas-lib)]
-       (.getFunction ^NativeLibrary system-blas fn-name)))))
+(defn has-blas?
+  []
+  (boolean (system-blas-lib)))
 
 
 (defn openblas?
   []
   (boolean
-   (get-blas-fn "openblas_get_num_threads")))
+   (when-let [system-blas (system-blas-lib)]
+     (jna/find-function "openblas_get_num_threads" *system-blas-lib-name*))))
 
 
-(defn openblas-get-num-threads
-  []
-  (let [^Function blas-fn (get-blas-fn "openblas_get_num_threads")]
-    (if blas-fn
-      (.invoke blas-fn Integer (object-array 0))
-      0)))
+(jna/def-jna-fn *system-blas-lib-name* openblas_get_num_threads
+  "Get number of openblas threads"
+  Integer)
 
 
-(defn openblas-set-num-threads
-  [num-threads]
-  (let [^Function blas-fn (get-blas-fn "openblas_set_num_threads")]
-    (when blas-fn
-      (.invoke blas-fn (object-array [(int num-threads)])))))
+(jna/def-jna-fn *system-blas-lib-name* openblas_set_num_threads
+  "Set number of openblas threads"
+  nil
+  [num-threads int])
+
 
 ;; typedef enum CBLAS_ORDER     {CblasRowMajor=101, CblasColMajor=102} CBLAS_ORDER;
 ;; typedef enum CBLAS_TRANSPOSE {CblasNoTrans=111, CblasTrans=112, CblasConjTrans=113, CblasConjNoTrans=114} CBLAS_TRANSPOSE;
@@ -65,11 +53,12 @@
    :left 141 :right 142})
 
 (defn enum-value
-  ^long [enum-name]
-  (if-let [retval (get enums enum-name)]
-    retval
-    (throw (ex-info "Failed to find enum:"
-                    {:enum-name enum-name}))))
+  [enum-name]
+  (int
+   (if-let [retval (get enums enum-name)]
+     retval
+     (throw (ex-info "Failed to find enum:"
+                     {:enum-name enum-name})))))
 
 ;; void cblas_sgemm(OPENBLAS_CONST enum CBLAS_ORDER Order,
 ;;                  OPENBLAS_CONST enum CBLAS_TRANSPOSE TransA,
@@ -77,7 +66,7 @@
 ;;                  OPENBLAS_CONST blasint M,
 ;;                  OPENBLAS_CONST blasint N,
 ;;                  OPENBLAS_CONST blasint K,
-;; 		 OPENBLAS_CONST float alpha,
+;; 		    OPENBLAS_CONST float alpha,
 ;;                  OPENBLAS_CONST float *A,
 ;;                  OPENBLAS_CONST blasint lda,
 ;;                  OPENBLAS_CONST float *B,
@@ -86,69 +75,51 @@
 ;;                  float *C, OPENBLAS_CONST blasint ldc);
 
 
-(defn has-blas?
-  []
-  (boolean
-   (get-blas-fn "cblas_sgemm")))
-
-
 (defn- ensure-blas
   []
   (when-not (has-blas?)
     (throw (ex-info "System blas is unavailable." {}))))
 
 
-(defn- ensure-blas-fn
-  [fn-name]
-  (if-let [retval (get-blas-fn fn-name)]
-    retval
-    (throw (ex-info "Blas fn not found" {:fn-name fn-name}))))
-
-
 (defn bool->blas-transpose
   [trans?]
-  (enum-value (if trans? :transpose :no-transpose)))
+  (int
+   (enum-value (if trans? :transpose :no-transpose))))
 
 
-(defn sgemm
-  [order trans-a? trans-b? M N K alpha A lda B ldb beta C ldc]
-  (ensure-blas)
-  (error-checking/ensure-datatypes :float32 A B C)
-  (when-let [blas-fn (ensure-blas-fn "cblas_sgemm")]
-    (.invoke blas-fn (object-array
-                      [(int (enum-value order))
-                       (int (bool->blas-transpose trans-a?))
-                       (int (bool->blas-transpose trans-b?))
-                       (int M)
-                       (int N)
-                       (int K)
-                       (float alpha)
-                       (primitive/->buffer-backing-store A)
-                       (int lda)
-                       (primitive/->buffer-backing-store B)
-                       (int ldb)
-                       (float beta)
-                       (primitive/->buffer-backing-store C)
-                       (int ldc)]))))
+(jna/def-jna-fn *system-blas-lib-name* cblas_sgemm
+  "float32 gemm"
+  nil
+  [order int]
+  [trans-a? bool->blas-transpose]
+  [trans-b? bool->blas-transpose]
+  [M int]
+  [N int]
+  [K int]
+  [alpha float]
+  [A primitive/ensure-ptr-like]
+  [lda int]
+  [B primitive/ensure-ptr-like]
+  [ldb int]
+  [beta float]
+  [C primitive/ensure-ptr-like]
+  [ldc int])
 
 
-(defn dgemm
-  [order trans-a? trans-b? M N K alpha A lda B ldb beta C ldc]
-  (ensure-blas)
-  (error-checking/ensure-datatypes :float64 A B C)
-  (when-let [blas-fn (ensure-blas-fn "cblas_dgemm")]
-    (.invoke blas-fn (object-array
-                      [(int (enum-value order))
-                       (int (bool->blas-transpose trans-a?))
-                       (int (bool->blas-transpose trans-b?))
-                       (int M)
-                       (int N)
-                       (int K)
-                       (double alpha)
-                       (primitive/->buffer-backing-store A)
-                       (int lda)
-                       (primitive/->buffer-backing-store B)
-                       (int ldb)
-                       (double beta)
-                       (primitive/->buffer-backing-store C)
-                       (int ldc)]))))
+(jna/def-jna-fn *system-blas-lib-name* cblas_dgemm
+  "float64 gemm"
+  nil
+  [order int]
+  [trans-a? bool->blas-transpose]
+  [trans-b? bool->blas-transpose]
+  [M int]
+  [N int]
+  [K int]
+  [alpha double]
+  [A primitive/ensure-ptr-like]
+  [lda int]
+  [B primitive/ensure-ptr-like]
+  [ldb int]
+  [beta double]
+  [C primitive/ensure-ptr-like]
+  [ldc int])

--- a/src/tech/compute/cpu/tensor_math.clj
+++ b/src/tech/compute/cpu/tensor_math.clj
@@ -37,64 +37,79 @@
 (defn- ->dimensions
   [tensor] (ct/tensor->dimensions tensor))
 
-(defn- assign-constant-map
-  []
-  (require '[tech.compute.cpu.tensor-math.assignment])
-  @(resolve 'tech.compute.cpu.tensor-math.assignment/assign-constant-map))
+
+(def ^:private lock-object (Object.))
 
 
-(defn- assign!-map
-  []
-  (require '[tech.compute.cpu.tensor-math.assignment])
-  @(resolve 'tech.compute.cpu.tensor-math.assignment/assign!-map))
+(defmacro ^:private threadsafe-constant
+  [& body]
+  `(memoize
+    (fn []
+      ;;There is no guarantee that require or resolve, called in many threads at once
+      ;;return what you think they might.  So we ensure exactly one thread at a time in
+      ;;this code.
+      (locking lock-object
+        ~@body))))
 
 
-(defn- unary-op-table
-  []
-  (require '[tech.compute.cpu.tensor-math.unary-op])
-  @(resolve 'tech.compute.cpu.tensor-math.unary-op/unary-op-table))
+(def assign-constant-map
+  (threadsafe-constant
+   (require '[tech.compute.cpu.tensor-math.assignment])
+   @(resolve 'tech.compute.cpu.tensor-math.assignment/assign-constant-map)))
 
 
-(defn- binary-accum-constant-table
-  []
-  (require '[tech.compute.cpu.tensor-math.binary-accum])
-  @(resolve 'tech.compute.cpu.tensor-math.binary-accum/binary-accum-constant-table))
+(def assign!-map
+  (threadsafe-constant
+   (require '[tech.compute.cpu.tensor-math.assignment])
+   @(resolve 'tech.compute.cpu.tensor-math.assignment/assign!-map)))
 
 
-(defn- binary-accum-table
-  []
-  (require '[tech.compute.cpu.tensor-math.binary-accum])
-  @(resolve 'tech.compute.cpu.tensor-math.binary-accum/binary-accum-table))
+(def unary-op-table
+  (threadsafe-constant
+   (require '[tech.compute.cpu.tensor-math.unary-op])
+   @(resolve 'tech.compute.cpu.tensor-math.unary-op/unary-op-table)))
 
 
-(defn- binary-op-constant-table
-  []
-  (require '[tech.compute.cpu.tensor-math.binary-op])
-  @(resolve 'tech.compute.cpu.tensor-math.binary-op/binary-op-constant-table))
+(def binary-accum-constant-table
+  (threadsafe-constant
+   (require '[tech.compute.cpu.tensor-math.binary-accum])
+   @(resolve 'tech.compute.cpu.tensor-math.binary-accum/binary-accum-constant-table)))
 
 
-(defn- binary-op-table
-  []
-  (require '[tech.compute.cpu.tensor-math.binary-op])
-  @(resolve 'tech.compute.cpu.tensor-math.binary-op/binary-op-table))
+(def binary-accum-table
+  (threadsafe-constant
+   (require '[tech.compute.cpu.tensor-math.binary-accum])
+   @(resolve 'tech.compute.cpu.tensor-math.binary-accum/binary-accum-table)))
 
 
-(defn- ternary-op-table
-  []
-  (require '[tech.compute.cpu.tensor-math.ternary-op])
-  @(resolve 'tech.compute.cpu.tensor-math.ternary-op/ternary-op-table))
+(def binary-op-constant-table
+  (threadsafe-constant
+   (require '[tech.compute.cpu.tensor-math.binary-op])
+   @(resolve 'tech.compute.cpu.tensor-math.binary-op/binary-op-constant-table)))
 
 
-(defn- unary-reduce-table
-  []
-  (require '[tech.compute.cpu.tensor-math.unary-reduce])
-  @(resolve 'tech.compute.cpu.tensor-math.unary-reduce/unary-reduce-table))
+(def binary-op-table
+  (threadsafe-constant
+   (require '[tech.compute.cpu.tensor-math.binary-op])
+   @(resolve 'tech.compute.cpu.tensor-math.binary-op/binary-op-table)))
 
 
-(defn- blas-fn-map
-  []
-  (require '[tech.compute.cpu.tensor-math.blas])
-  @(resolve 'tech.compute.cpu.tensor-math.blas/blas-fn-map))
+(def ternary-op-table
+  (threadsafe-constant
+   (require '[tech.compute.cpu.tensor-math.ternary-op])
+   @(resolve 'tech.compute.cpu.tensor-math.ternary-op/ternary-op-table)))
+
+
+(def unary-reduce-table
+  (threadsafe-constant
+   (require '[tech.compute.cpu.tensor-math.unary-reduce])
+   @(resolve 'tech.compute.cpu.tensor-math.unary-reduce/unary-reduce-table)))
+
+
+(def blas-fn-map
+  (threadsafe-constant
+   (require '[tech.compute.cpu.tensor-math.blas])
+   @(resolve 'tech.compute.cpu.tensor-math.blas/blas-fn-map)))
 
 
 

--- a/src/tech/compute/cpu/typed_buffer.clj
+++ b/src/tech/compute/cpu/typed_buffer.clj
@@ -5,7 +5,6 @@
             [tech.compute.driver :as drv]
             [tech.compute :as compute]
             [tech.compute.registry :as registry]
-            [tech.resource :as resource]
             [tech.compute.cpu.utils :as cpu-utils])
     (:import  [java.nio ByteBuffer ShortBuffer IntBuffer
                LongBuffer FloatBuffer DoubleBuffer]
@@ -87,9 +86,6 @@
            (identical? lhs-ary rhs-ary)
            (cpu-utils/in-range? (get-offset lhs) (get-length lhs)
                                 (get-offset rhs) (get-length rhs)))))
-  ;;For uniformity all host/device buffers must implement the resource protocol.
-  resource/PResource
-  (release-resource [_])
   drv/PDeviceProvider
   (get-device [buffer]
     (-> (registry/driver :tech.compute.cpu.driver)
@@ -103,7 +99,7 @@
   [java-type]
   `(clojure.core/extend
        ~java-type
-          drv/PBuffer
+     drv/PBuffer
      {:sub-buffer (fn [item# offset# len#]
                     (drv/sub-buffer (unsigned/->typed-buffer item#)
                                     offset# len#))
@@ -113,9 +109,6 @@
       :partially-alias? (fn [lhs# rhs#]
                           (drv/partially-alias? (unsigned/->typed-buffer lhs#)
                                                 (unsigned/->typed-buffer rhs#)))}
-     resource/PResource
-     (:release-resource (fn [item#]))
-
      drv/PDeviceProvider
      {:get-device (fn [item#]
                     (drv/get-device (unsigned/->typed-buffer item#)))}

--- a/src/tech/compute/cpu/typed_pointer.clj
+++ b/src/tech/compute/cpu/typed_pointer.clj
@@ -1,10 +1,10 @@
 (ns tech.compute.cpu.typed-pointer
   (:require [tech.datatype.jna :as dtype-jna]
+            [tech.jna :as jna]
             [tech.compute.driver :as drv]
             [tech.compute :as compute]
             [tech.datatype :as dtype]
             [tech.compute.cpu.utils :as cpu-utils]
-            [tech.resource :as resource]
             [tech.compute.registry :as registry]
             [tech.datatype.javacpp :as jcpp-dtype])
   (:import [tech.datatype.jna TypedPointer]
@@ -19,15 +19,13 @@
 
 (defn- thing->addr
   ^long [item]
-  (-> (dtype-jna/->ptr-backing-store item)
+  (-> (jna/->ptr-backing-store item)
       dtype-jna/pointer->address))
 
 
 (defn maybe->typed-pointer
   [item]
-  (if (satisfies? dtype-jna/PToPtr item)
-    (or (dtype-jna/as-typed-pointer item)
-        (dtype-jna/->typed-pointer item))))
+  (dtype-jna/as-typed-pointer item))
 
 
 (extend-type TypedPointer
@@ -62,9 +60,6 @@
             rhs-addr (thing->addr rhs)]
         (cpu-utils/in-range? lhs-addr (dtype/ecount lhs)
                              rhs-addr (dtype/ecount rhs)))))
-  ;;For uniformity all host/device buffers must implement the resource protocol.
-  resource/PResource
-  (release-resource [_])
   drv/PDeviceProvider
   (get-device [buffer]
     (-> (drv/get-driver buffer)

--- a/src/tech/compute/tensor/error_checking.clj
+++ b/src/tech/compute/tensor/error_checking.clj
@@ -46,13 +46,25 @@
     {}))
 
 
+(defn simple-tensor?
+  [tensor]
+  (and (tens-proto/dense? tensor)
+       (dims/access-increasing? (tens-proto/tensor->dimensions tensor))))
+
+
+(defn ensure-simple-tensor
+  [tensor]
+  (when-not-error (simple-tensor? tensor)
+    "Tensor must be 'simple' - dense, linearly increasing memory access"
+    {:tensor-dimensons (tens-proto/tensor->dimensions tensor)})
+  tensor)
+
+
 (defn memcpy-semantics?
   [dest src]
   (and (= (dtype/ecount dest) (dtype/ecount src))
-       (tens-proto/dense? dest)
-       (tens-proto/dense? src)
-       (dims/access-increasing? (tens-proto/tensor->dimensions dest))
-       (dims/access-increasing? (tens-proto/tensor->dimensions src))
+       (simple-tensor? dest)
+       (simple-tensor? src)
        (= (dtype/get-datatype dest)
           (dtype/get-datatype src))))
 

--- a/src/tech/compute/tensor/operations.clj
+++ b/src/tech/compute/tensor/operations.clj
@@ -1,8 +1,7 @@
 (ns tech.compute.tensor.operations
   "tensor operations with syntatic sugar"
   (:refer-clojure :exclude [max min * / - + > >= < <= bit-and bit-xor])
-  (:require [clojure.core.matrix :as m]
-            [tech.compute.tensor :as tensor]
+  (:require [tech.compute.tensor :as tensor]
             [tech.datatype.base :as dtype]))
 
 (defn max
@@ -127,7 +126,7 @@
 (defn new-tensor
   "Returns a new tensor of the same shape and type of the given output tensor"
   [output]
-  (tensor/new-tensor (m/shape output) :datatype (dtype/get-datatype output)))
+  (tensor/new-tensor (dtype/shape output) :datatype (dtype/get-datatype output)))
 
 (defn where
   "Takes a tests tensor of 1s and 0s and a tensor of then and a tensor of else.

--- a/src/tech/compute/verify/tensor/operations.clj
+++ b/src/tech/compute/verify/tensor/operations.clj
@@ -220,6 +220,5 @@
          new-ten (tops/new-tensor test-ten)]
      (is (= (ct/shape test-ten) (ct/shape new-ten)))
      (is (= (dtype/get-datatype test-ten) (dtype/get-datatype new-ten)))
-     (println new-ten)
      (is (m/equals [0.0 0.0 0.0 0.0 0.0]
                    (ct/to-double-array new-ten))))))

--- a/src/tech/compute/verify/tensor/operations.clj
+++ b/src/tech/compute/verify/tensor/operations.clj
@@ -218,7 +218,8 @@
    driver datatype
    (let [test-ten (ct/->tensor [1 0 0 1 0])
          new-ten (tops/new-tensor test-ten)]
-     (is (= (m/shape test-ten) (m/shape new-ten)))
+     (is (= (ct/shape test-ten) (ct/shape new-ten)))
      (is (= (dtype/get-datatype test-ten) (dtype/get-datatype new-ten)))
+     (println new-ten)
      (is (m/equals [0.0 0.0 0.0 0.0 0.0]
                    (ct/to-double-array new-ten))))))

--- a/test/tech/compute/cpu/tensor_operations_test.clj
+++ b/test/tech/compute/cpu/tensor_operations_test.clj
@@ -68,4 +68,4 @@
   (verify-tensor-operations/where-operation (driver) *datatype*))
 
 (def-all-dtype-test new-tensor-operation
-  (verify-tensor-operations/new-tensor-operation (driver) *datatype*))
+  (verify-tensor-operations/new-tensor-operation (driver) :uint32))


### PR DESCRIPTION
1.  Use system blas everywhere possible instead of using netlib.
2.  ->tensor can return base buffer type for rank-1 objects.
3.  Move to datatype 2.X system.