### PR TITLE
Fixes for Clojure 1.10 + Linux

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :plugins [[lein-tools-deps "0.4.1"]]
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
-  :lein-tools-deps/config {:config-files [:install :user :project]}
+  :lein-tools-deps/config {:config-files [:install :user :project]
+                           :clojure-executables ["/usr/local/bin/clojure"
+                                                 "/usr/bin/clojure"]}
   :java-source-paths ["java"]
   :profiles {:dev {:dependencies [[com.github.fommil.netlib/all "1.1.2" :extension "pom"]]}})

--- a/src/tech/compute/cpu/typed_pointer.clj
+++ b/src/tech/compute/cpu/typed_pointer.clj
@@ -8,8 +8,7 @@
             [tech.compute.registry :as registry]
             [tech.datatype.javacpp :as jcpp-dtype])
   (:import [tech.datatype.jna TypedPointer]
-           [com.sun.jna Pointer]
-           [org.bytedeco.javacpp.Pointer]))
+           [com.sun.jna Pointer]))
 
 
 


### PR DESCRIPTION
This commit has two fixes:

1) It adds linux default install paths to the `lein-tools-deps` clojure executables search path (so that linux users can help contribute to this project)

2) It removes an unnecessary import in `typed_pointer`, which didn't adhere to clojure 1.10's namespace specs (causing this, and therefore `tech.ml`) to not be usable w/ clojure 1.10. Since the protocol extension was using the full namespace anyway, importing it, I believe, is unnecessary.

I'm not 100% sure, but as far as I could tell it seemed to work fine. Unfortunately I'm having issues getting tests running on my machine, so if they work for you locally, it's probably worth testing to make sure that this doesn't inadvertently break anything.